### PR TITLE
11.0.2 `GetAddonInfo` changes to `C_AddOns.GetAddonInfo`

### DIFF
--- a/ElvUI_SystemDatatext.lua
+++ b/ElvUI_SystemDatatext.lua
@@ -100,8 +100,8 @@ local function RebuildAddonList()
 	memoryTable = {}
 	cpuTable = {}
 	for i = 1, addonCount do
-		memoryTable[i] = {i, select(2, GetAddOnInfo(i)), 0, IsAddOnLoaded(i)}
-		cpuTable[i] = {i, select(2, GetAddOnInfo(i)), 0, IsAddOnLoaded(i)}
+		memoryTable[i] = {i, select(2, C_AddOns.GetAddonInfo(i)), 0, IsAddOnLoaded(i)}
+		cpuTable[i] = {i, select(2, C_AddOns.GetAddonInfo(i)), 0, IsAddOnLoaded(i)}
 	end
 end
 


### PR DESCRIPTION
`GetAddonInfo` changes to `C_AddOns.GetAddonInfo`